### PR TITLE
fuse: invalidate inode aliases when doing inode invalidation

### DIFF
--- a/fs/fuse/fuse_i.h
+++ b/fs/fuse/fuse_i.h
@@ -723,6 +723,12 @@ struct fuse_conn {
 	 */
 	unsigned handle_killpriv_v2:1;
 
+	/*  invalidate inode entries when doing inode invalidation */
+	unsigned inval_inode_entries:1;
+
+	/*  expire inode entries when doing inode invalidation */
+	unsigned expire_inode_entries:1;
+
 	/*
 	 * The following bitfields are only for optimization purposes
 	 * and hence races in setting them will not cause malfunction

--- a/fs/fuse/inode.c
+++ b/fs/fuse/inode.c
@@ -542,6 +542,45 @@ struct inode *fuse_ilookup(struct fuse_conn *fc, u64 nodeid,
 	return NULL;
 }
 
+static void fuse_prune_aliases(struct inode *inode)
+{
+	struct dentry *dentry;
+
+	spin_lock(&inode->i_lock);
+	hlist_for_each_entry(dentry, &inode->i_dentry, d_u.d_alias) {
+		fuse_invalidate_entry_cache(dentry);
+	}
+	spin_unlock(&inode->i_lock);
+
+	d_prune_aliases(inode);
+}
+
+static void fuse_invalidate_inode_entry(struct inode *inode)
+{
+	struct dentry *dentry;
+
+	if (S_ISDIR(inode->i_mode)) {
+		/* For directories, use d_invalidate to handle children and submounts */
+		dentry = d_find_alias(inode);
+		if (dentry) {
+			d_invalidate(dentry);
+			fuse_invalidate_entry_cache(dentry);
+			dput(dentry);
+		}
+	} else {
+		/* For regular files, just unhash the dentry */
+		spin_lock(&inode->i_lock);
+		hlist_for_each_entry(dentry, &inode->i_dentry, d_u.d_alias) {
+			spin_lock(&dentry->d_lock);
+			if (!d_unhashed(dentry))
+				__d_drop(dentry);
+			spin_unlock(&dentry->d_lock);
+			fuse_invalidate_entry_cache(dentry);
+		}
+		spin_unlock(&inode->i_lock);
+	}
+}
+
 int fuse_reverse_inval_inode(struct fuse_conn *fc, u64 nodeid,
 			     loff_t offset, loff_t len)
 {
@@ -558,6 +597,11 @@ int fuse_reverse_inval_inode(struct fuse_conn *fc, u64 nodeid,
 	spin_lock(&fi->lock);
 	fi->attr_version = atomic64_inc_return(&fc->attr_version);
 	spin_unlock(&fi->lock);
+
+	if (fc->inval_inode_entries)
+		fuse_invalidate_inode_entry(inode);
+	else if (fc->expire_inode_entries)
+		fuse_prune_aliases(inode);
 
 	fuse_invalidate_attr(inode);
 	forget_all_cached_acls(inode);
@@ -1374,6 +1418,10 @@ static void process_init_reply(struct fuse_mount *fm, struct fuse_args *args,
 				fc->io_uring = 1;
 			if (flags & FUSE_NO_EXPORT_SUPPORT)
 				fm->sb->s_export_op = &fuse_export_fid_operations;
+			if (flags & FUSE_INVAL_INODE_ENTRY)
+				fc->inval_inode_entries = 1;
+			if (flags & FUSE_EXPIRE_INODE_ENTRY)
+				fc->expire_inode_entries = 1;
 		} else {
 			ra_pages = fc->max_read / PAGE_SIZE;
 			fc->no_lock = 1;
@@ -1424,7 +1472,7 @@ void fuse_send_init(struct fuse_mount *fm)
 		FUSE_HANDLE_KILLPRIV_V2 | FUSE_SETXATTR_EXT | FUSE_INIT_EXT |
 		FUSE_SECURITY_CTX | FUSE_CREATE_SUPP_GROUP |
 		FUSE_HAS_EXPIRE_ONLY | FUSE_DIRECT_IO_ALLOW_MMAP |
-		FUSE_NO_EXPORT_SUPPORT;
+		FUSE_NO_EXPORT_SUPPORT | FUSE_INVAL_INODE_ENTRY | FUSE_EXPIRE_INODE_ENTRY;
 #ifdef CONFIG_FUSE_DAX
 	if (fm->fc->dax)
 		flags |= FUSE_MAP_ALIGNMENT;

--- a/include/uapi/linux/fuse.h
+++ b/include/uapi/linux/fuse.h
@@ -427,6 +427,8 @@ struct fuse_file_lock {
  * FUSE_DIRECT_IO_ALLOW_MMAP: allow shared mmap in FOPEN_DIRECT_IO mode.
  * FUSE_NO_EXPORT_SUPPORT: explicitly disable export support
  * FUSE_OVER_IO_URING: Indicate that client supports io-uring
+ * FUSE_INVAL_INODE_ENTRY: invalidate inode aliases when doing inode invalidation
+ * FUSE_EXPIRE_INODE_ENTRY: expire inode aliases when doing inode invalidation
  */
 #define FUSE_ASYNC_READ		(1 << 0)
 #define FUSE_POSIX_LOCKS	(1 << 1)
@@ -471,6 +473,8 @@ struct fuse_file_lock {
 /* Obsolete alias for FUSE_DIRECT_IO_ALLOW_MMAP */
 #define FUSE_DIRECT_IO_RELAX	FUSE_DIRECT_IO_ALLOW_MMAP
 #define FUSE_OVER_IO_URING	(1ULL << 41)
+#define FUSE_INVAL_INODE_ENTRY  (1ULL << 60)
+#define FUSE_EXPIRE_INODE_ENTRY (1ULL << 61)
 
 /**
  * CUSE INIT request/reply flags


### PR DESCRIPTION
    fuse: invalidate inode aliases when doing inode invalidation

    Add support to invalidate inode aliases when doing inode invalidation.
    This is useful for distributed file systems, which use DLM for cache
    coherency. So, when a client losts its inode lock, it should invalidate
    its inode cache and dentry cache since the other client may delete
    this file after getting inode lock.