### PR TITLE
Redfs ubuntu aligned writes

### DIFF
--- a/fs/fuse/file.c
+++ b/fs/fuse/file.c
@@ -1984,8 +1984,9 @@ static void fuse_writepages_send(struct fuse_fill_wb_data *data)
 
 
 static bool fuse_writepage_need_send(struct fuse_conn *fc, struct page *page,
-				     struct fuse_args_pages *ap,
-				     struct fuse_fill_wb_data *data)
+					struct fuse_args_pages *ap,
+					struct fuse_fill_wb_data *data,
+					struct writeback_control *wbc)
 {
 	WARN_ON(!ap->num_pages);
 
@@ -2004,6 +2005,17 @@ static bool fuse_writepage_need_send(struct fuse_conn *fc, struct page *page,
 	/* Need to grow the pages array?  If so, did the expansion fail? */
 	if (ap->num_pages == data->max_pages && !fuse_pages_realloc(data))
 		return true;
+
+	/* Reached alignment */
+	if (fc->alignment_pages && !(page->index % fc->alignment_pages)) {
+		/* we are at a point where we would write aligned
+		 * check if we potentially could reach the next alignment */
+		if (page->index + fc->alignment_pages > wbc->range_end)
+			return true;
+
+		if (ap->num_pages + fc->alignment_pages > fc->max_pages)
+			return true;
+	}
 
 	return false;
 }
@@ -2026,7 +2038,7 @@ static int fuse_writepages_fill(struct folio *folio,
 			goto out_unlock;
 	}
 
-	if (wpa && fuse_writepage_need_send(fc, &folio->page, ap, data)) {
+	if (wpa && fuse_writepage_need_send(fc, &folio->page, ap, data, wbc)) {
 		fuse_writepages_send(data);
 		data->wpa = NULL;
 	}

--- a/fs/fuse/fuse_i.h
+++ b/fs/fuse/fuse_i.h
@@ -926,6 +926,10 @@ struct fuse_conn {
 	/**  uring connection information*/
 	struct fuse_ring *ring;
 #endif
+
+	/* The foffset alignment in PAGE */
+	unsigned int alignment_pages;
+
 };
 
 /*

--- a/fs/fuse/inode.c
+++ b/fs/fuse/inode.c
@@ -1416,6 +1416,14 @@ static void process_init_reply(struct fuse_mount *fm, struct fuse_args *args,
 				fc->direct_io_allow_mmap = 1;
 			if (flags & FUSE_OVER_IO_URING && fuse_uring_enabled())
 				fc->io_uring = 1;
+
+			if (flags & FUSE_ALIGN_PG_ORDER) {
+				if (arg->align_page_order > 0) {
+					fc->alignment_pages =
+					(1UL << arg->align_page_order)
+					>> PAGE_SHIFT;
+				}
+			}
 			if (flags & FUSE_NO_EXPORT_SUPPORT)
 				fm->sb->s_export_op = &fuse_export_fid_operations;
 			if (flags & FUSE_INVAL_INODE_ENTRY)

--- a/include/uapi/linux/fuse.h
+++ b/include/uapi/linux/fuse.h
@@ -429,6 +429,8 @@ struct fuse_file_lock {
  * FUSE_OVER_IO_URING: Indicate that client supports io-uring
  * FUSE_INVAL_INODE_ENTRY: invalidate inode aliases when doing inode invalidation
  * FUSE_EXPIRE_INODE_ENTRY: expire inode aliases when doing inode invalidation
+ * FUSE_ALIGN_PG_ORDER: page order (power of 2 exponent for number of pages) for
+ *			optimal io-size alignment
  */
 #define FUSE_ASYNC_READ		(1 << 0)
 #define FUSE_POSIX_LOCKS	(1 << 1)
@@ -473,6 +475,9 @@ struct fuse_file_lock {
 /* Obsolete alias for FUSE_DIRECT_IO_ALLOW_MMAP */
 #define FUSE_DIRECT_IO_RELAX	FUSE_DIRECT_IO_ALLOW_MMAP
 #define FUSE_OVER_IO_URING	(1ULL << 41)
+
+#define FUSE_ALIGN_PG_ORDER	(1ULL << 50)
+
 #define FUSE_INVAL_INODE_ENTRY  (1ULL << 60)
 #define FUSE_EXPIRE_INODE_ENTRY (1ULL << 61)
 
@@ -891,6 +896,9 @@ struct fuse_init_in {
 #define FUSE_COMPAT_INIT_OUT_SIZE 8
 #define FUSE_COMPAT_22_INIT_OUT_SIZE 24
 
+/*
+ * align_page_order: Number of pages for optimal IO, or a multiple of that
+ */
 struct fuse_init_out {
 	uint32_t	major;
 	uint32_t	minor;
@@ -903,7 +911,10 @@ struct fuse_init_out {
 	uint16_t	max_pages;
 	uint16_t	map_alignment;
 	uint32_t	flags2;
-	uint32_t	unused[7];
+	uint32_t	max_stack_depth;
+	uint8_t		align_page_order;
+	uint8_t		padding[3];
+	uint32_t	unused[5];
 };
 
 #define CUSE_INIT_INFO_MAX 4096


### PR DESCRIPTION
add an option to communicate alignment from the fuse server to the kernel and the kernel to obey alignment set by the fuse server.
Note that the writepage code in the kernel can only work restrictively (basically deciding, that it has to write out the buffer this call to fuse_writepages_fill).

This patch will check against the wbc range_end if we can write another aligned block and write out the buffer if not.
This will lead to write operations that will end on an aligned boundary. And then have a smaller write operation at the end that starts on an aligned boundary.

This patch will also check if we can write another aligned buffer until we hit the max_pages limit. This happens a lot when we don't start on an aligned position the max_pages will also be unaligned and that leads to almost the complete write process will be unaligned.

The patch cannot ensure aligned writes but it will keep the write operations as aligned as the mm write cache operation allows.