### PR TITLE
fuse: change FUSE DLM_LOCK to request start and end of area

### DIFF
--- a/fs/fuse/file.c
+++ b/fs/fuse/file.c
@@ -2222,8 +2222,8 @@ static int fuse_get_page_mkwrite_lock(struct file *file, loff_t offset, size_t l
 	memset(&inarg, 0, sizeof(inarg));
 	inarg.fh = ff->fh;
 
-	inarg.offset = offset;
-	inarg.size = length;
+	inarg.start = offset;
+	inarg.end = offset + length - 1;
 	inarg.type = FUSE_DLM_PAGE_MKWRITE;
 
 	args.opcode = FUSE_DLM_WB_LOCK;
@@ -2240,10 +2240,13 @@ static int fuse_get_page_mkwrite_lock(struct file *file, loff_t offset, size_t l
 		err = 0;
 	}
 
-	if (!err && fc->dlm && outarg.locksize < length) {
+	if (!err &&
+		fc->dlm &&
+		(outarg.start > inarg.start ||
+	    outarg.end < inarg.end)) {
 		/* fuse server is seriously broken */
-		pr_warn("fuse: dlm lock request for %lu bytes returned %u bytes\n",
-			length, outarg.locksize);
+		pr_warn("fuse: dlm lock request for %llu:%llu bytes returned %llu:%llu bytes\n",
+			inarg.start, inarg.end, outarg.start, outarg.end);
 		fuse_abort_conn(fc);
 		err = -EINVAL;
 	}

--- a/fs/fuse/fuse_dlm_cache.h
+++ b/fs/fuse/fuse_dlm_cache.h
@@ -32,16 +32,16 @@ int fuse_dlm_cache_init(struct fuse_inode *inode);
 void fuse_dlm_cache_release_locks(struct fuse_inode *inode);
 
 /* Lock a range of pages */
-int fuse_dlm_lock_range(struct fuse_inode *inode, pgoff_t start,
-			pgoff_t end, enum fuse_page_lock_mode mode);
+int fuse_dlm_lock_range(struct fuse_inode *inode, uint64_t start,
+			uint64_t end, enum fuse_page_lock_mode mode);
 
 /* Unlock a range of pages */
-int fuse_dlm_unlock_range(struct fuse_inode *inode, pgoff_t start,
-			  pgoff_t end);
+int fuse_dlm_unlock_range(struct fuse_inode *inode, uint64_t start,
+			  uint64_t end);
 
 /* Check if a page range is already locked */
-bool fuse_dlm_range_is_locked(struct fuse_inode *inode, pgoff_t start,
-			      pgoff_t end, enum fuse_page_lock_mode mode);
+bool fuse_dlm_range_is_locked(struct fuse_inode *inode, uint64_t start,
+			      uint64_t end, enum fuse_page_lock_mode mode);
 
 /* this is the interface to the filesystem */
 void fuse_get_dlm_write_lock(struct file *file, loff_t offset,

--- a/include/uapi/linux/fuse.h
+++ b/include/uapi/linux/fuse.h
@@ -1198,10 +1198,10 @@ enum fuse_dlm_lock_type {
  */
 struct fuse_dlm_lock_in {
 	uint64_t    fh;
-	uint64_t    offset;
-	uint32_t    size;
+	uint64_t    start;
+	uint64_t    end;
 	uint32_t    type;
-	uint64_t    reserved;
+	uint32_t    reserved;
 };
 
 /**
@@ -1211,8 +1211,9 @@ struct fuse_dlm_lock_in {
  * to reduce number of calls)
  */
 struct fuse_dlm_lock_out {
-	uint32_t locksize;
-	uint32_t padding;
+	uint64_t start;
+	uint64_t end;
+	uint64_t reserved;
 };
 
 /**


### PR DESCRIPTION
- Increase the possible lock size to 64 bit.
- change semantics of DLM locks to request start and end
- change semantics of DLM request return to mark start and end of the locked area
- better prepare dlm lock range cache rb-tree for unaligned byte range locks which could return
any value as long as it is larger than the range
requested
- add the case where start and end are zero to destroy the cache