### PR TITLE
fuse: change FUSE DLM_LOCK to request start and end of area

### DIFF
--- a/fs/fuse/fuse_dlm_cache.h
+++ b/fs/fuse/fuse_dlm_cache.h
@@ -32,16 +32,16 @@ int fuse_dlm_cache_init(struct fuse_inode *inode);
 void fuse_dlm_cache_release_locks(struct fuse_inode *inode);
 
 /* Lock a range of pages */
-int fuse_dlm_lock_range(struct fuse_inode *inode, pgoff_t start,
-			pgoff_t end, enum fuse_page_lock_mode mode);
+int fuse_dlm_lock_range(struct fuse_inode *inode, uint64_t start,
+			uint64_t end, enum fuse_page_lock_mode mode);
 
 /* Unlock a range of pages */
-int fuse_dlm_unlock_range(struct fuse_inode *inode, pgoff_t start,
-			  pgoff_t end);
+int fuse_dlm_unlock_range(struct fuse_inode *inode, uint64_t start,
+			  uint64_t end);
 
 /* Check if a page range is already locked */
-bool fuse_dlm_range_is_locked(struct fuse_inode *inode, pgoff_t start,
-			      pgoff_t end, enum fuse_page_lock_mode mode);
+bool fuse_dlm_range_is_locked(struct fuse_inode *inode, uint64_t start,
+			      uint64_t end, enum fuse_page_lock_mode mode);
 
 /* this is the interface to the filesystem */
 void fuse_get_dlm_write_lock(struct file *file, loff_t offset,

--- a/fs/fuse/inode.c
+++ b/fs/fuse/inode.c
@@ -620,11 +620,14 @@ int fuse_reverse_inval_inode(struct fuse_conn *fc, u64 nodeid,
 			pg_end = (offset + len - 1) >> PAGE_SHIFT;
 
 		if (fc->dlm && fc->writeback_cache)
-			/* invalidate the range from the beginning of the first page
-			 * in the given range to the last byte of the last page */
+			/* Invalidate the range exactly as the fuse server requested
+			 * except for the case where it sends -1.
+			 * Note that this can lead to some inconsistencies if
+			 * the fuse server sends unaligned data */
 			fuse_dlm_unlock_range(fi,
-								pg_start << PAGE_SHIFT,
-								(pg_end << PAGE_SHIFT) | (PAGE_SIZE - 1));
+								offset,
+								pg_end == -1 ? 0 :
+								(offset + len - 1));
 
 		invalidate_inode_pages2_range(inode->i_mapping,
 					      pg_start, pg_end);

--- a/include/uapi/linux/fuse.h
+++ b/include/uapi/linux/fuse.h
@@ -1253,10 +1253,10 @@ enum fuse_dlm_lock_type {
  */
 struct fuse_dlm_lock_in {
 	uint64_t    fh;
-	uint64_t    offset;
-	uint32_t    size;
+	uint64_t    start;
+	uint64_t    end;
 	uint32_t    type;
-	uint64_t    reserved;
+	uint32_t    reserved;
 };
 
 /**
@@ -1266,8 +1266,9 @@ struct fuse_dlm_lock_in {
  * to reduce number of calls)
  */
 struct fuse_dlm_lock_out {
-	uint32_t locksize;
-	uint32_t padding;
+	uint64_t start;
+	uint64_t end;
+	uint64_t reserved;
 };
 
 /**


### PR DESCRIPTION
- Increase the possible lock size to 64 bit.
- change semantics of DLM locks to request start and end
- change semantics of DLM request return to mark start and end of the locked area
- better prepare dlm lock range cache rb-tree for unaligned byte range locks which could return
any value as long as it is larger than the range
requested
- add the case where start and end are zero to destroy the cache


(cherry picked from commit e30a00ff5723291a3ce298d36892cb2696100117)