### PR TITLE
limit the inode and dentry cache via parameter in fuse_init

### DIFF
--- a/fs/fuse/control.c
+++ b/fs/fuse/control.c
@@ -184,6 +184,28 @@ out:
 	return ret;
 }
 
+static ssize_t fuse_conn_inode_count_read(struct file *file, char __user *buf,
+					   size_t len, loff_t *ppos)
+{
+	struct fuse_conn *fc;
+	unsigned long count;
+	char tmp[32];
+	size_t size;
+
+	if (*ppos)
+		return 0;
+
+	fc = fuse_ctl_file_conn_get(file);
+	if (!fc)
+		return 0;
+
+	count = atomic64_read(&fc->num_inodes);
+	fuse_conn_put(fc);
+
+	size = sprintf(tmp, "%lu\n", count);
+	return simple_read_from_buffer(buf, len, ppos, tmp, size);
+}
+
 static const struct file_operations fuse_ctl_abort_ops = {
 	.open = nonseekable_open,
 	.write = fuse_conn_abort_write,
@@ -207,6 +229,12 @@ static const struct file_operations fuse_conn_congestion_threshold_ops = {
 	.open = nonseekable_open,
 	.read = fuse_conn_congestion_threshold_read,
 	.write = fuse_conn_congestion_threshold_write,
+	.llseek = no_llseek,
+};
+
+static const struct file_operations fuse_conn_inode_count_ops = {
+	.open = nonseekable_open,
+	.read = fuse_conn_inode_count_read,
 	.llseek = no_llseek,
 };
 
@@ -278,7 +306,9 @@ int fuse_ctl_add_conn(struct fuse_conn *fc)
 				 1, NULL, &fuse_conn_max_background_ops) ||
 	    !fuse_ctl_add_dentry(parent, fc, "congestion_threshold",
 				 S_IFREG | 0600, 1, NULL,
-				 &fuse_conn_congestion_threshold_ops))
+				 &fuse_conn_congestion_threshold_ops) ||
+	    !fuse_ctl_add_dentry(parent, fc, "inode_count", S_IFREG | 0400, 1,
+				 NULL, &fuse_conn_inode_count_ops))
 		goto err;
 
 	return 0;

--- a/fs/fuse/control.c
+++ b/fs/fuse/control.c
@@ -206,6 +206,39 @@ static ssize_t fuse_conn_inode_count_read(struct file *file, char __user *buf,
 	return simple_read_from_buffer(buf, len, ppos, tmp, size);
 }
 
+static ssize_t fuse_conn_dentry_count_read(struct file *file, char __user *buf,
+					    size_t len, loff_t *ppos)
+{
+	struct fuse_mount *fm;
+	struct super_block *sb;
+	struct fuse_conn *fc;
+	unsigned long count;
+	char tmp[32];
+	size_t size;
+
+	if (*ppos)
+		return 0;
+
+	fc = fuse_ctl_file_conn_get(file);
+	if (!fc)
+		return 0;
+
+	count = 0;
+	down_read(&fc->killsb);
+	list_for_each_entry(fm, &fc->mounts, fc_entry) {
+		sb = fm->sb;
+		if (!sb)
+			continue;
+
+		count += list_lru_count(&sb->s_dentry_lru);
+	}
+	up_read(&fc->killsb);
+	fuse_conn_put(fc);
+
+	size = sprintf(tmp, "%lu\n", count);
+	return simple_read_from_buffer(buf, len, ppos, tmp, size);
+}
+
 static const struct file_operations fuse_ctl_abort_ops = {
 	.open = nonseekable_open,
 	.write = fuse_conn_abort_write,
@@ -235,6 +268,12 @@ static const struct file_operations fuse_conn_congestion_threshold_ops = {
 static const struct file_operations fuse_conn_inode_count_ops = {
 	.open = nonseekable_open,
 	.read = fuse_conn_inode_count_read,
+	.llseek = no_llseek,
+};
+
+static const struct file_operations fuse_conn_dentry_count_ops = {
+	.open = nonseekable_open,
+	.read = fuse_conn_dentry_count_read,
 	.llseek = no_llseek,
 };
 
@@ -308,7 +347,9 @@ int fuse_ctl_add_conn(struct fuse_conn *fc)
 				 S_IFREG | 0600, 1, NULL,
 				 &fuse_conn_congestion_threshold_ops) ||
 	    !fuse_ctl_add_dentry(parent, fc, "inode_count", S_IFREG | 0400, 1,
-				 NULL, &fuse_conn_inode_count_ops))
+				 NULL, &fuse_conn_inode_count_ops) ||
+	    !fuse_ctl_add_dentry(parent, fc, "dentry_count", S_IFREG | 0400, 1,
+				 NULL, &fuse_conn_dentry_count_ops))
 		goto err;
 
 	return 0;

--- a/fs/fuse/dir.c
+++ b/fs/fuse/dir.c
@@ -22,6 +22,9 @@
 #include <linux/security.h>
 #include <linux/types.h>
 #include <linux/kernel.h>
+#include <linux/dcache.h>
+#include <linux/list_lru.h>
+#include <linux/workqueue.h>
 
 static bool __read_mostly allow_sys_admin_access;
 module_param(allow_sys_admin_access, bool, 0644);
@@ -2232,4 +2235,126 @@ void fuse_init_symlink(struct inode *inode)
 	inode->i_op = &fuse_symlink_inode_operations;
 	inode->i_data.a_ops = &fuse_symlink_aops;
 	inode_nohighmem(inode);
+}
+
+static enum lru_status fuse_lru_isolate(struct list_head *item,
+					 struct list_lru_one *lru,
+					 spinlock_t *lru_lock,
+					 void *arg)
+{
+	struct dentry *dentry = container_of(item, struct dentry, d_lru);
+	struct fuse_prune_ctx *ctx = arg;
+
+	if (!spin_trylock(&dentry->d_lock))
+		return LRU_SKIP;
+
+	/* Skip dentries that are in use or already unhashed */
+	if (dentry->d_lockref.count > 0 || d_unhashed(dentry)) {
+		spin_unlock(&dentry->d_lock);
+		return LRU_SKIP;
+	}
+
+	/* Skip negative dentries - they don't have inodes to forget */
+	if (!d_inode(dentry)) {
+		spin_unlock(&dentry->d_lock);
+		return LRU_ROTATE;
+	}
+
+	/* Skip directories - d_invalidate() would recursively shrink children */
+	if (d_is_dir(dentry)) {
+		spin_unlock(&dentry->d_lock);
+		return LRU_ROTATE;
+	}
+
+	/* Check if we've collected enough dentries */
+	if (ctx->count >= ctx->max) {
+		spin_unlock(&dentry->d_lock);
+		return LRU_SKIP;
+	}
+
+	/* Grab a reference and collect this dentry for pruning */
+	dget_dlock(dentry);
+	spin_unlock(&dentry->d_lock);
+
+	ctx->dentries[ctx->count++] = dentry;
+	return LRU_ROTATE;
+}
+
+static void fuse_lru_prune_worker(struct work_struct *work)
+{
+	struct fuse_mount *fm = container_of(work, struct fuse_mount,
+					     lru_prune_work.work);
+	struct super_block *sb;
+	unsigned long i;
+
+	down_read(&fm->fc->killsb);
+	sb = fm->sb;
+	if (!sb) {
+		up_read(&fm->fc->killsb);
+		return;
+	}
+
+	fm->prune_ctx.count = 0;
+	fm->prune_ctx.max = ARRAY_SIZE(fm->prune_ctx.dentries);
+
+	if (fm->max_inodes && atomic64_read(&fm->fc->num_inodes) > fm->max_inodes) {
+		unsigned long to_scan = atomic64_read(&fm->fc->num_inodes) - fm->max_inodes;
+		list_lru_walk(&sb->s_dentry_lru, fuse_lru_isolate, &fm->prune_ctx,
+			      min(to_scan, (unsigned long)ARRAY_SIZE(fm->prune_ctx.dentries)));
+	}
+
+	up_read(&fm->fc->killsb);
+
+	/*
+	 * Invalidate dentries to free them and send FORGET to server.
+	 * We only collected non-directory dentries, so d_invalidate()
+	 * won't recursively shrink children.
+	 *
+	 * Since we're only collecting the exact excess (not being aggressive),
+	 * this should be safe and won't flood the server with FORGET requests.
+	 */
+	for (i = 0; i < fm->prune_ctx.count; i++) {
+		d_invalidate(fm->prune_ctx.dentries[i]);
+		dput(fm->prune_ctx.dentries[i]);
+	}
+}
+
+void fuse_lru_prune_init(struct fuse_mount *fm, unsigned long max_inodes)
+{
+	INIT_DELAYED_WORK(&fm->lru_prune_work, fuse_lru_prune_worker);
+	fuse_lru_prune_set_inode_limit(fm, max_inodes);
+}
+
+void fuse_lru_prune_stop(struct fuse_mount *fm)
+{
+	if (fm->max_inodes == 0)
+		return;
+
+	fm->max_inodes = 0;
+	cancel_delayed_work_sync(&fm->lru_prune_work);
+}
+
+void fuse_lru_prune_set_inode_limit(struct fuse_mount *fm, unsigned long max_inodes)
+{
+	WRITE_ONCE(fm->max_inodes, max_inodes);
+}
+
+bool fuse_lru_prune_trigger(struct fuse_mount *fm)
+{
+	struct super_block *sb;
+
+	if (fm->max_inodes == 0)
+		return false;
+
+	sb = READ_ONCE(fm->sb);
+	if (!sb)
+		return false;
+
+	if (fm->max_inodes > 0 &&
+	    atomic64_read(&fm->fc->num_inodes) > fm->max_inodes) {
+		mod_delayed_work(system_wq, &fm->lru_prune_work, 0);
+		return true;
+	}
+
+	return false;
 }

--- a/fs/fuse/fuse_i.h
+++ b/fs/fuse/fuse_i.h
@@ -47,7 +47,7 @@
 #define FUSE_NAME_MAX (PATH_MAX - 1)
 
 /** Number of dentries for each connection in the control filesystem */
-#define FUSE_CTL_NUM_DENTRIES 5
+#define FUSE_CTL_NUM_DENTRIES 6
 
 /** Maximum of max_pages received in init_out */
 extern unsigned int fuse_max_pages_limit;
@@ -898,6 +898,8 @@ struct fuse_conn {
 
 	/** Version counter for evict inode */
 	atomic64_t evict_ctr;
+
+	atomic64_t num_inodes;
 
 	/* maximum file name length */
 	u32 name_max;

--- a/fs/fuse/fuse_i.h
+++ b/fs/fuse/fuse_i.h
@@ -47,7 +47,7 @@
 #define FUSE_NAME_MAX (PATH_MAX - 1)
 
 /** Number of dentries for each connection in the control filesystem */
-#define FUSE_CTL_NUM_DENTRIES 6
+#define FUSE_CTL_NUM_DENTRIES 7
 
 /** Maximum of max_pages received in init_out */
 extern unsigned int fuse_max_pages_limit;

--- a/fs/fuse/fuse_i.h
+++ b/fs/fuse/fuse_i.h
@@ -940,6 +940,15 @@ struct fuse_conn {
 
 };
 
+#define FUSE_PRUNE_DENTRY_BATCH 512
+
+/* Prune context - used by the worker to collect dentries */
+struct fuse_prune_ctx {
+	struct dentry *dentries[FUSE_PRUNE_DENTRY_BATCH];
+	unsigned long count;
+	unsigned long max;
+};
+
 /*
  * Represents a mounted filesystem, potentially a submount.
  *
@@ -960,6 +969,13 @@ struct fuse_mount {
 	/* Entry on fc->mounts */
 	struct list_head fc_entry;
 	struct rcu_head rcu;
+
+	/* LRU pruning worker */
+	struct delayed_work lru_prune_work;
+	unsigned long max_inodes;
+
+	/* Prune context - used by the worker to collect dentries */
+	struct fuse_prune_ctx prune_ctx;
 };
 
 /*
@@ -1495,5 +1511,11 @@ extern void fuse_sysctl_unregister(void);
 #define fuse_sysctl_register()		(0)
 #define fuse_sysctl_unregister()	do { } while (0)
 #endif /* CONFIG_SYSCTL */
+
+/* Unified LRU pruning for dentries and inodes (on-demand only) */
+void fuse_lru_prune_init(struct fuse_mount *fm, unsigned long max_inodes);
+void fuse_lru_prune_stop(struct fuse_mount *fm);
+void fuse_lru_prune_set_inode_limit(struct fuse_mount *fm, unsigned long max_inodes);
+bool fuse_lru_prune_trigger(struct fuse_mount *fm);
 
 #endif /* _FS_FUSE_I_H */

--- a/fs/fuse/inode.c
+++ b/fs/fuse/inode.c
@@ -182,6 +182,7 @@ static void fuse_evict_inode(struct inode *inode)
 		 */
 		if (inode->i_nlink > 0)
 			atomic64_inc(&fc->evict_ctr);
+		atomic64_dec(&fc->num_inodes);
 	}
 	if (S_ISREG(inode->i_mode) && !fuse_is_bad(inode)) {
 		WARN_ON(!list_empty(&fi->write_files));
@@ -504,6 +505,7 @@ retry:
 		inode->i_generation = generation;
 		fuse_init_inode(inode, attr, fc);
 		unlock_new_inode(inode);
+		atomic64_inc(&fc->num_inodes);
 	} else if (fuse_stale_inode(inode, generation, attr)) {
 		/* nodeid was reused, any I/O on the old inode should fail */
 		fuse_make_bad(inode);
@@ -1036,6 +1038,7 @@ void fuse_conn_init(struct fuse_conn *fc, struct fuse_mount *fm,
 
 	atomic64_set(&fc->attr_version, 1);
 	atomic64_set(&fc->evict_ctr, 1);
+	atomic64_set(&fc->num_inodes, 0);
 	get_random_bytes(&fc->scramble_key, sizeof(fc->scramble_key));
 	fc->pid_ns = get_pid_ns(task_active_pid_ns(current));
 	fc->user_ns = get_user_ns(user_ns);

--- a/fs/fuse/inode.c
+++ b/fs/fuse/inode.c
@@ -153,15 +153,16 @@ static void fuse_cleanup_submount_lookup(struct fuse_conn *fc,
 static void fuse_evict_inode(struct inode *inode)
 {
 	struct fuse_inode *fi = get_fuse_inode(inode);
+	struct fuse_conn *fc = get_fuse_conn(inode);
 
 	/* Will write inode on close/munmap and in all other dirtiers */
 	WARN_ON(inode->i_state & I_DIRTY_INODE);
 
 	truncate_inode_pages_final(&inode->i_data);
 	clear_inode(inode);
-	if (inode->i_sb->s_flags & SB_ACTIVE) {
-		struct fuse_conn *fc = get_fuse_conn(inode);
+	atomic64_dec(&fc->num_inodes);
 
+	if (inode->i_sb->s_flags & SB_ACTIVE) {
 		if (FUSE_IS_DAX(inode))
 			fuse_dax_inode_cleanup(inode);
 		if (fi->nlookup) {
@@ -182,7 +183,6 @@ static void fuse_evict_inode(struct inode *inode)
 		 */
 		if (inode->i_nlink > 0)
 			atomic64_inc(&fc->evict_ctr);
-		atomic64_dec(&fc->num_inodes);
 	}
 	if (S_ISREG(inode->i_mode) && !fuse_is_bad(inode)) {
 		WARN_ON(!list_empty(&fi->write_files));
@@ -522,6 +522,9 @@ retry:
 done:
 	fuse_change_attributes_i(inode, attr, NULL, attr_valid, attr_version,
 				 evict_ctr);
+
+	fuse_lru_prune_trigger(get_fuse_mount_super(sb));
+
 	return inode;
 }
 
@@ -1038,7 +1041,6 @@ void fuse_conn_init(struct fuse_conn *fc, struct fuse_mount *fm,
 
 	atomic64_set(&fc->attr_version, 1);
 	atomic64_set(&fc->evict_ctr, 1);
-	atomic64_set(&fc->num_inodes, 0);
 	get_random_bytes(&fc->scramble_key, sizeof(fc->scramble_key));
 	fc->pid_ns = get_pid_ns(task_active_pid_ns(current));
 	fc->user_ns = get_user_ns(user_ns);
@@ -1458,6 +1460,10 @@ static void process_init_reply(struct fuse_mount *fm, struct fuse_args *args,
 		fc->max_write = arg->minor < 5 ? 4096 : arg->max_write;
 		fc->max_write = max_t(unsigned, 4096, fc->max_write);
 		fc->conn_init = 1;
+
+		/* Initialize unified LRU pruning if inode limit is set */
+		if (arg->max_inodes > 0)
+			fuse_lru_prune_init(fm, arg->max_inodes);
 	}
 	kfree(ia);
 
@@ -2103,6 +2109,7 @@ static void fuse_sb_destroy(struct super_block *sb)
 
 void fuse_mount_destroy(struct fuse_mount *fm)
 {
+	fuse_lru_prune_stop(fm);
 	fuse_conn_put(fm->fc);
 	kfree_rcu(fm, rcu);
 }

--- a/include/uapi/linux/fuse.h
+++ b/include/uapi/linux/fuse.h
@@ -905,9 +905,6 @@ struct fuse_init_in {
 #define FUSE_COMPAT_INIT_OUT_SIZE 8
 #define FUSE_COMPAT_22_INIT_OUT_SIZE 24
 
-/*
- * align_page_order: Number of pages for optimal IO, or a multiple of that
- */
 struct fuse_init_out {
 	uint32_t	major;
 	uint32_t	minor;

--- a/include/uapi/linux/fuse.h
+++ b/include/uapi/linux/fuse.h
@@ -920,7 +920,8 @@ struct fuse_init_out {
 	uint32_t	max_stack_depth;
 	uint8_t		align_page_order;
 	uint8_t		padding[3];
-	uint32_t	unused[5];
+	uint32_t	max_inodes;
+	uint32_t	unused[4];
 };
 
 #define CUSE_INIT_INFO_MAX 4096


### PR DESCRIPTION
- added the inodes in the cache to /sys/fs/fuse/connection/
- added the number of dentrys in the cache to fusectl
I thought it would be beneficial to be able to see the cache filling reported per connetion

- added max_inodes to the FUSE_INIT parameters
- added a background task that invalidates dentries that are over the limit