### PR TITLE
Revert "fuse: invalidate the page cache after direct write"

### DIFF
--- a/fs/fuse/file.c
+++ b/fs/fuse/file.c
@@ -754,18 +754,6 @@ static void fuse_aio_complete(struct fuse_io_priv *io, int err, ssize_t pos)
 			struct inode *inode = file_inode(io->iocb->ki_filp);
 			struct fuse_conn *fc = get_fuse_conn(inode);
 			struct fuse_inode *fi = get_fuse_inode(inode);
-			struct address_space *mapping = io->iocb->ki_filp->f_mapping;
-
-			/*
-			 * As in generic_file_direct_write(), invalidate after the
-			 * write, to invalidate read-ahead cache that may have competed
-			 * with the write.
-			 */
-			if (io->write && res && mapping->nrpages) {
-				invalidate_inode_pages2_range(mapping,
-						io->offset >> PAGE_SHIFT,
-						(io->offset + res - 1) >> PAGE_SHIFT);
-			}
 
 			spin_lock(&fi->lock);
 			fi->attr_version = atomic64_inc_return(&fc->attr_version);
@@ -1140,11 +1128,9 @@ static ssize_t fuse_send_write(struct fuse_io_args *ia, loff_t pos,
 {
 	struct kiocb *iocb = ia->io->iocb;
 	struct file *file = iocb->ki_filp;
-	struct address_space *mapping = file->f_mapping;
 	struct fuse_file *ff = file->private_data;
 	struct fuse_mount *fm = ff->fm;
 	struct fuse_write_in *inarg = &ia->write.in;
-	ssize_t written;
 	ssize_t err;
 
 	fuse_write_args_fill(ia, ff, pos, count);
@@ -1158,26 +1144,10 @@ static ssize_t fuse_send_write(struct fuse_io_args *ia, loff_t pos,
 		return fuse_async_req_send(fm, ia, count);
 
 	err = fuse_simple_request(fm, &ia->ap.args);
-	written = ia->write.out.size;
-	if (!err && written > count)
+	if (!err && ia->write.out.size > count)
 		err = -EIO;
 
-	/*
-	 * Without FOPEN_DIRECT_IO, generic_file_direct_write() does the
-	 * invalidation for us.
-	 */
-	if (!err && written && mapping->nrpages &&
-	    (ff->open_flags & FOPEN_DIRECT_IO)) {
-		/*
-		 * As in generic_file_direct_write(), invalidate after the
-		 * write, to invalidate read-ahead cache that may have competed
-		 * with the write.
-		 */
-		invalidate_inode_pages2_range(mapping, pos >> PAGE_SHIFT,
-					(pos + written - 1) >> PAGE_SHIFT);
-	}
-
-	return err ?: written;
+	return err ?: ia->write.out.size;
 }
 
 bool fuse_write_update_attr(struct inode *inode, loff_t pos, ssize_t written)
@@ -1705,6 +1675,15 @@ ssize_t fuse_direct_io(struct fuse_io_priv *io, struct iov_iter *iter,
 		fuse_io_free(ia);
 	if (res > 0)
 		*ppos = pos;
+
+	if (res > 0 && write && fopen_direct_io) {
+		/*
+		 * As in generic_file_direct_write(), invalidate after the
+		 * write, to invalidate read-ahead cache that may have competed
+		 * with the write.
+		 */
+		invalidate_inode_pages2_range(mapping, idx_from, idx_to);
+	}
 
 	return res > 0 ? res : err;
 }


### PR DESCRIPTION
This reverts commit f6de786cb23689f0ee235a2dc75a991d30a90198.
f6de786cb causes deadlock on coroutine based fuse daemon when running AIO + buffered I/O mixed workload.