### PR TITLE
fuse: Remove double define of 'enable_large_folios' module param

### DIFF
--- a/fs/fuse/inode.c
+++ b/fs/fuse/inode.c
@@ -37,7 +37,7 @@ static bool __read_mostly enable_compound;
 module_param(enable_compound, bool, 0644);
 MODULE_PARM_DESC(enable_uring, "Enable fuse compounds");
 
-static bool __read_mostly enable_large_folios = true;
+bool __read_mostly enable_large_folios = true;
 module_param(enable_large_folios, bool, 0644);
 MODULE_PARM_DESC(enable_large_folios, "Enable large folios support");
 


### PR DESCRIPTION
compilation failed, due to external and static, given it is used in file.c, but defined in inode.c - just remove "static".