### PR TITLE
fuse: don't leak AOP_TRUNCATED_PAGE from fuse_write_begin()

### DIFF
--- a/fs/fuse/file.c
+++ b/fs/fuse/file.c
@@ -2252,10 +2252,12 @@ static int fuse_write_begin(struct file *file, struct address_space *mapping,
 	struct fuse_conn *fc = get_fuse_conn(file_inode(file));
 	struct page *page;
 	loff_t fsize;
-	int err = -ENOMEM;
+	int err;
 
 	WARN_ON(!fc->writeback_cache);
 
+retry:
+	err = -ENOMEM;
 	page = grab_cache_page_write_begin(mapping, index);
 	if (!page)
 		goto error;
@@ -2285,6 +2287,13 @@ success:
 cleanup:
 	unlock_page(page);
 	put_page(page);
+	/*
+	 * ->write_begin has no AOP_TRUNCATED_PAGE contract; a positive
+	 * return would pass the "status < 0" check in
+	 * generic_perform_write() and crash on an unset *pagep.
+	 */
+	if (err == AOP_TRUNCATED_PAGE)
+		goto retry;
 error:
 	return err;
 }


### PR DESCRIPTION
fuse_do_readpage() may return AOP_TRUNCATED_PAGE (a positive value) when the daemon fails its DLM lock acquisition with -EAGAIN during an in-flight invalidation. fuse_read_folio() is prepared for that, but fuse_write_begin() forwarded it to generic_perform_write(), which only treats negative returns as errors and went on to use the never-initialized page pointer: the user copy is silently fixed up as a 0-byte short copy and fuse_write_end() then oopses in unlock_page(NULL).

Retry the page grab and read inside fuse_write_begin() instead, mirroring the read-side retry done by filemap_fault().

Fixes: 8ecf11820538 ("fuse: Allow read_folio to retry page fault and read operations")