### PR TITLE
fuse: only refresh size on cached write when opened with O_APPEND

### DIFF
--- a/fs/fuse/file.c
+++ b/fs/fuse/file.c
@@ -1833,9 +1833,12 @@ static ssize_t fuse_cache_write_iter(struct kiocb *iocb, struct iov_iter *from)
 		return fuse_direct_write_iter(iocb, from);
 
 	if (fc->writeback_cache) {
-		/* Update size (EOF optimization) and mode (SUID clearing) */
-		err = fuse_update_attributes(mapping->host, file,
-					     STATX_SIZE | STATX_MODE);
+		/* Update mode for SUID clearing, and also update size if the file
+		 * is opened with O_APPEND mode.
+		 */
+		u32 request_mask = (file->f_flags & O_APPEND) ?
+				   (STATX_SIZE | STATX_MODE) : STATX_MODE;
+		err = fuse_update_attributes(mapping->host, file, request_mask);
 		if (err)
 			return err;
 


### PR DESCRIPTION
In fuse_cache_write_iter, writeback_cache mode was always refreshing STATX_SIZE along with STATX_MODE before a buffered write. The size refresh is only needed for the O_APPEND path, where the kernel must know the current EOF before extending the file. For ordinary writes, fetching size is unnecessary work and can race with concurrent writes and then impact writeback performance.

Keep refreshing STATX_MODE in all cases so SUID clearing still sees an up-to-date mode. Request STATX_SIZE only when the file is opened with O_APPEND.

Signed-off-by Hai Zhong Zhou <hazhou@ddn.com>